### PR TITLE
Simplify phrasing of equals checks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ When a test fails, the message is always a variation of "Expected [right], but g
 
     array.should.contain.only(values);
 
+    range.should.contain.exactly(values); // unordered comparison
+
 # Strings
 
     string.should.not.be.empty;

--- a/src/dshould/basic.d
+++ b/src/dshould/basic.d
@@ -307,8 +307,8 @@ if (isInstanceOf!(ShouldType, Should)
 
         check(
             mixin(format!(enums.checkString)("got", "expected")),
-            format("value %s", enums.message.format(expected.quote)),
-            format("%s", got.quote),
+            format(enums.message, expected.quote),
+            got.quote,
             file, line
         );
     }
@@ -332,8 +332,8 @@ if (isInstanceOf!(ShouldType, Should)
 
         check(
             mixin(format!(enums.checkString)("got", "expected")),
-            format("value %s", enums.message.format(expected.quote)),
-            format("%s", got.quote),
+            format(enums.message, expected.quote),
+            got.quote,
             file, line
         );
     }
@@ -357,8 +357,8 @@ if (isInstanceOf!(ShouldType, Should)
 
         check(
             mixin(format!(enums.checkString)("got.array", "expected.array")),
-            format("value %s", enums.message.format(expected.quote)),
-            format("%s", got.quote),
+            format(enums.message, expected.quote),
+            got.quote,
             file, line
         );
     }
@@ -378,12 +378,17 @@ private template numericComparison(Should, T)
     static if (Should.hasWord!"not")
     {
         enum checkString = "!(%s " ~ combined ~ " %s)";
-        enum message = "not " ~ combined ~ " %s";
+        enum message = "value not " ~ combined ~ " %s";
+    }
+    else static if (combined == "==")
+    {
+        enum checkString = "%s == %s";
+        enum message = "%s";
     }
     else
     {
         enum checkString = "%s " ~ combined ~ " %s";
-        enum message = combined ~ " %s";
+        enum message = "value " ~ combined ~ " %s";
     }
 }
 
@@ -519,7 +524,7 @@ package string quote(T)(T t)
     {
         if (t.isNull)
         {
-            return (typeof(cast() t)).stringof ~ ".null";
+            return "Nullable.null";
         }
     }
 

--- a/src/dshould/package.d
+++ b/src/dshould/package.d
@@ -171,7 +171,7 @@ unittest
 @("prints informative errors for int comparison")
 unittest
 {
-    2.should.be(3).should.throwA!FluentException("Test failed: expected value == 3, but got 2");
+    2.should.be(3).should.throwA!FluentException("Test failed: expected 3, but got 2");
 }
 
 @("prints informative errors for object comparison")
@@ -281,15 +281,26 @@ unittest
         ("Test failed: expected Nullable.null, but got 42");
 }
 
-@("nullable equality")
+@("nullable equality with value")
 unittest
 {
     import std.typecons : Nullable;
 
     Nullable!string().should.not.equal("");
 
-    Nullable!string().should.equal("").should.throwA!FluentException
-        ("Test failed: expected value == '', but got Nullable!string.null");
+    Nullable!string().should.equal("")
+        .should.throwA!FluentException("Test failed: expected '', but got Nullable.null");
+}
+
+@("value equality with nullable")
+unittest
+{
+    import std.typecons : Nullable;
+
+    "".should.not.equal(Nullable!string());
+
+    "".should.equal(Nullable!string())
+        .should.throwA!FluentException("Test failed: expected Nullable.null, but got ''");
 }
 
 @("exception thrown by value is not hijacked by unterminated should-chain error")
@@ -324,5 +335,6 @@ unittest
     auto second = new Class;
 
     (first == second).should.be(false);
-    first.should.equal(second).should.throwAn!Exception("Test failed: expected Class, but got Class");
+    first.should.equal(second)
+        .should.throwAn!Exception("Test failed: expected Class, but got Class");
 }


### PR DESCRIPTION
Simplify phrasing of equals checks.
Report `Nullable!T.null` as "Nullable.null", not "Nullable!T.null".